### PR TITLE
Add JOIN shorthand with a join hash mimicing SQL's JOIN.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.14.6
+
+* Add `left.join(right, {x1 => y1, ..., xn => yn})` as a shorthand for
+  `left.join(right.rename({y1 => x1, ..., yn => xn}, [x1,...,xn])`.
+  This allows joining ala SQL, i.e. with attributes differing on each
+  operand. A difference with SQL, though, is that the `ys` attributes
+  are no longer present in the join result.
+
 # 0.14.5 - 2019/01/23
 
 * Optimize `extend.page` by pushing the page down the tree when

--- a/lib/bmg/algebra.rb
+++ b/lib/bmg/algebra.rb
@@ -166,6 +166,6 @@ module Bmg
     end
 
     require_relative 'algebra/shortcuts'
-    include Shortcuts
+    prepend Algebra::Shortcuts
   end # module Algebra
 end # module Bmg

--- a/lib/bmg/algebra/shortcuts.rb
+++ b/lib/bmg/algebra/shortcuts.rb
@@ -25,6 +25,14 @@ module Bmg
         self.rename(renaming)
       end
 
+      def join(right, on = [])
+        return super unless on.is_a?(Hash)
+        renaming = on.each_pair.inject({}){|r, (k,v)|
+          r.merge(v => k)
+        }
+        self.join(right.rename(renaming), on.keys)
+      end
+
     end # module Shortcuts
   end # module Algebra
 end # module Bmg

--- a/spec/unit/algebra/shortcuts/test_join.rb
+++ b/spec/unit/algebra/shortcuts/test_join.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+module Bmg
+  module Algebra
+    describe Shortcuts, "join" do
+
+      let(:left) {
+        Relation.new([
+          { a: "foo",  b: 2 },
+          { a: "bar",  b: 2 }
+        ], Type::ANY.with_attrlist([:a, :b]))
+      }
+
+      let(:right) {
+        Relation.new([
+          { z: "foo",  c: 4 },
+          { z: "baz",  c: 4 }
+        ], Type::ANY.with_attrlist([:a, :c]))
+      }
+
+      subject {
+        left.join(right, :a => :z)
+      }
+
+      it 'compiles as expected' do
+        expect(subject).to be_a(Operator::Join)
+        expect(left_operand(subject)).to be(left)
+        expect(right_operand(subject)).to be_a(Operator::Rename)
+        expect(right_operand(subject).send(:renaming)).to eql({:z => :a})
+        expect(subject.send(:on)).to eql([:a])
+      end
+
+      it 'works as expected' do        
+        expect(subject.to_a).to eql([
+          { a: "foo", b: 2, c: 4 }
+        ])
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
This commit adds a JOIN operator that works with a join hash
specifying the attributes that must be equal on each side. This
is a simple shorthand for a longer expression making use of a
rename on the right operand.