### PR TITLE
make Path a dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     bmg (0.17.3)
+      path (>= 1.3)
       predicate (~> 2.3, >= 2.3.3)
 
 GEM
@@ -41,7 +42,6 @@ PLATFORMS
 
 DEPENDENCIES
   bmg!
-  path (>= 1.3)
   rake (~> 10)
   roo (>= 2.7)
   rspec (~> 3.6)

--- a/bmg.gemspec
+++ b/bmg.gemspec
@@ -14,11 +14,11 @@ Gem::Specification.new do |s|
   s.homepage    = 'http://github.com/enspirit/bmg'
   s.license     = 'MIT'
 
+  s.add_dependency "path", ">= 1.3"
   s.add_dependency "predicate", "~> 2.3", ">= 2.3.3"
 
   s.add_development_dependency "rake", "~> 10"
   s.add_development_dependency "rspec", "~> 3.6"
-  s.add_development_dependency "path", ">= 1.3"
   s.add_development_dependency "roo", ">= 2.7"
   s.add_development_dependency "sequel"
   s.add_development_dependency "sqlite3"


### PR DESCRIPTION
Trying to load this in a Rails app produces a LoadError.

I think path needs to be included as a dependency (not just dev dependency) because it's referenced in
[lib/bmg.rb](https://github.com/enspirit/bmg/blob/abd062e689e35534bbfa33a267868d0290633eba/lib/bmg.rb#L1)

I was looking for a library that does just this a couple of weeks ago and this just popped up on HN, great stuff!